### PR TITLE
kibana-docker: use 6.2 branch

### DIFF
--- a/build-kibana-docker-image.sh
+++ b/build-kibana-docker-image.sh
@@ -6,6 +6,7 @@ KIBANA_TAG=$3
 
 git clone https://github.com/elastic/kibana-docker.git
 cd kibana-docker
+git checkout --track origin/6.2
 
 ELASTIC_REGISTRY=quay.io \
 IMAGE_TAG=${HUQ_DOCKER_REGISTRY_ORG}/kibana \


### PR DESCRIPTION
Use kibana-docker 6.2 branch. Otherwise, the build fails because x-pack is going to be open sourced and the build system is changing